### PR TITLE
cups-filter had missing dependency that per-recipe-sysroots turned up

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ other layers needed, e.g.::
     /path/to/yocto/meta-yocto-bsp \
     /path/to/yocto/meta-openembedded/meta-oe \
     /path/to/yocto/meta-openembedded/meta-python \
-    /path/to/yocto/meta-meta-printing \
+    /path/to/yocto/meta-printing \
     "
 
 If you need networking support, also add meta-openembedded/meta-networking to
@@ -86,7 +86,7 @@ II. Misc
 
 Newer kernel recipes:
 
-For a few (very) recent beaglebone or mips octeon kernels add the `meta-small-arm`_
+For a few recent beaglebone, socfpga, imx6, or mips octeon kernels add the `meta-small-arm`_
 mini-bsp layer and leave the above defaults as-is.
 
 .. _meta-small-arm: https://github.com/sarnold/meta-small-arm-extra

--- a/recipes-printing/cups/cups-filters.inc
+++ b/recipes-printing/cups/cups-filters.inc
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=1905bf57de6c8e9e3893ede5e214daea"
 
 SECTION = "console/utils"
 
-DEPENDS = "cups glib-2.0 dbus dbus-glib lcms ghostscript poppler qpdf libpng"
+DEPENDS = "cups glib-2.0 glib-2.0-native dbus dbus-glib lcms ghostscript poppler qpdf libpng"
 DEPENDS_class-native = "poppler-native glib-2.0-native dbus-native pkgconfig-native gettext-native libpng-native"
 
 SRC_URI = "http://openprinting.org/download/cups-filters/cups-filters-${PV}.tar.gz"


### PR DESCRIPTION
Yay for more reproducible builds thanks to the new sysroot strictness :-)
