### PR TITLE
Got cups-filters 1.14.0 and cups 2.2.3 working in Pyro.

### DIFF
--- a/recipes-printing/cups/cups-filters.inc
+++ b/recipes-printing/cups/cups-filters.inc
@@ -2,11 +2,11 @@ DESCRIPTION = "CUPS backends, filters, and other software"
 HOMEPAGE = "http://www.linuxfoundation.org/collaborate/workgroups/openprinting/cups-filters"
 
 LICENSE = "GPLv2 & LGPLv2 & MIT & GPLv2+ & GPLv3"
-LIC_FILES_CHKSUM = "file://COPYING;md5=1905bf57de6c8e9e3893ede5e214daea"
+LIC_FILES_CHKSUM = "file://COPYING;md5=a4c88b7020cef4a77b4321f78cbe1e1c"
 
 SECTION = "console/utils"
 
-DEPENDS = "cups glib-2.0 dbus dbus-glib lcms ghostscript poppler qpdf libpng"
+DEPENDS = "cups glib-2.0 glib-2.0-native dbus dbus-glib lcms ghostscript poppler qpdf libpng"
 DEPENDS_class-native = "poppler-native glib-2.0-native dbus-native pkgconfig-native gettext-native libpng-native"
 
 SRC_URI = "http://openprinting.org/download/cups-filters/cups-filters-${PV}.tar.gz"
@@ -63,6 +63,7 @@ FILES_${PN}-dbg += "\
 FILES_${PN} += "\
         ${libdir}/cups/filter \
         ${libdir}/cups/backend \
+        ${libdir}/cups/driver/driverless \
         /usr/share/cups/charsets \
         /usr/share/cups/drv \
         /usr/share/cups/mime \
@@ -95,3 +96,7 @@ do_install_append() {
 }
 
 RDEPENDS_${PN} += "bash"
+
+# This is needed if multiple recipes copy to the same directories
+# By default, files in RPM packages own all their parents.
+DIRFILES = "1"

--- a/recipes-printing/cups/cups-filters_1.10.0.bb
+++ b/recipes-printing/cups/cups-filters_1.10.0.bb
@@ -1,5 +1,0 @@
-include cups-filters.inc
-
-#SRC_URI = "https://github.com/Distrotech/${PN}/archive/release-1-5-0.tar.gz"
-SRC_URI[md5sum] = "58370ca8e628e9a5f15009a1021f42cc"
-SRC_URI[sha256sum] = "8de1473385ed0556f3aa488ee60a19c5f0c24b5a86e96c9b022c68275cb30900"

--- a/recipes-printing/cups/cups-filters_1.14.0.bb
+++ b/recipes-printing/cups/cups-filters_1.14.0.bb
@@ -1,0 +1,5 @@
+include cups-filters.inc
+
+#SRC_URI = "https://github.com/Distrotech/${PN}/archive/release-1-5-0.tar.gz"
+SRC_URI[md5sum] = "3d8b28661daa8ffd5ae7ec0a7c3f6dd5"
+SRC_URI[sha256sum] = "6ba1b29afdec79486597b818302e20abeb94b067a0ef151d2e1c8168e935dfd6"

--- a/recipes-printing/cups/cups.inc
+++ b/recipes-printing/cups/cups.inc
@@ -23,7 +23,7 @@ LEAD_SONAME = "libcupsdriver.so"
 
 CLEANBROKEN = "1"
 
-inherit autotools-brokensep binconfig update-rc.d useradd systemd
+inherit autotools-brokensep binconfig update-rc.d useradd systemd pkgconfig
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM_${PN} = "--system lpadmin"

--- a/recipes-printing/cups/cups_2.1.4.bb
+++ b/recipes-printing/cups/cups_2.1.4.bb
@@ -1,6 +1,0 @@
-require cups.inc
-
-LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=6c5a350596fba02754bd96eb6df3afd0"
-
-SRC_URI[md5sum] = "9f9bf6e3b9c20a3519b4dc409666d6e7"
-SRC_URI[sha256sum] = "4b14fd833180ac529ebebea766a09094c2568bf8426e219cb3a1715304ef728d"

--- a/recipes-printing/cups/cups_2.2.3.bb
+++ b/recipes-printing/cups/cups_2.2.3.bb
@@ -1,0 +1,6 @@
+require cups.inc
+
+LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=f212b4338db0da8cb892e94bf2949460"
+
+SRC_URI[md5sum] = "006a8156680a516e43c59034e31df8bf"
+SRC_URI[sha256sum] = "66701fe15838f2c892052c913bde1ba106bbee2e0a953c955a62ecacce76885f"


### PR DESCRIPTION
Got meta-printing bitbaking in Pyro and also upgraded to the latest cups-filters and cups. 

I added DIRFILES = "1" to cups-filters as I wanted to have both cups and cups-filters in my built image and this is needed so there isn't RPM package ownership issues.