### PR TITLE
cups: check files exist before sourcing it in init.d script

### DIFF
--- a/recipes-printing/cups/cups/cups.init
+++ b/recipes-printing/cups/cups/cups.init
@@ -17,11 +17,11 @@ PIDFILE="/var/run/cups/cups.sock"
 OPTS="-F -C ${CONFIG_D} -s ${CONFIG_FILES}"
 
 # Source function library.
-. /etc/init.d/functions
+[ -e /etc/init.d/functions ] && . /etc/init.d/functions
 
 # source rcS and default cupsd settings
-. /etc/default/rcS
-. /etc/default/cups
+[ -e /etc/default/rcS  ] && . /etc/default/rcS
+[ -e /etc/default/cups ] && . /etc/default/cups
 
 if [ ! -d $CERTSDIR ]; then
     mkdir -p $CERTSDIR


### PR DESCRIPTION
cupsd init.d script should check the existence of files which should be sourced before actually sourcing them so if a default file don't exist, it doesn't fail.