### PR TITLE
fixed qa issue compile-host-path by replacing /usr/local/include by

### DIFF
--- a/recipes-devtools/python/python-pillow_3.3.0.bb
+++ b/recipes-devtools/python/python-pillow_3.3.0.bb
@@ -35,6 +35,7 @@ do_compile_prepend() {
                -e s:/lib:${STAGING_BASELIBDIR}:g \
                -e s:/lib64:${STAGING_BASELIBDIR}:g \
                -e s:/usr/include:${STAGING_INCDIR}:g \
+               -e s:/usr/local/include:${STAGING_INCDIR}:g \
                ${S}/setup.py
 }
 


### PR DESCRIPTION
The recipe produced an qa error, because /usr/local/include was not replaced, adding it to the other replacement lines fixed my problem. 