### PR TITLE
pycups: Support for python3

### DIFF
--- a/recipes-devtools/python/python-pycups.inc
+++ b/recipes-devtools/python/python-pycups.inc
@@ -7,6 +7,6 @@ SRC_URI = "https://github.com/Distrotech/pycups/archive/${PV}.tar.gz"
 SRC_URI[md5sum] = "0d151fc723e8596761cbc5913e380c2e"
 SRC_URI[sha256sum] = "5062106731b41f68e3a65ea1eccdb580ef6d95b11c07b4da64f09501348d238f"
 
-inherit setuptools
+DEPENDS += " cups"
+RDEPENDS_${PN} += " cups"
 
-RDEPENDS_${PN} = "cups"

--- a/recipes-devtools/python/python-pycups_1.9.73.bb
+++ b/recipes-devtools/python/python-pycups_1.9.73.bb
@@ -1,0 +1,2 @@
+inherit pypi setuptools
+require python-pycups.inc

--- a/recipes-devtools/python/python3-pycups_1.9.73.bb
+++ b/recipes-devtools/python/python3-pycups_1.9.73.bb
@@ -1,0 +1,2 @@
+inherit pypi setuptools3
+require python-pycups.inc


### PR DESCRIPTION
The latest version of [system-config-printer ](https://github.com/zdohnal/system-config-printer/blob/master/udev/udev-add-printer#L1)requires the Python3 version of pycups.
I have separated the recipe into Python2 and Python3.

common : python-pycups.inc
python2.x : python-pycups_1.9.73.bb
python3.x : python3-pycups_1.9.73.bb