### PR TITLE
cups.inc: add pkgconfig-native as dependencies because it's necessary for libusb support

### DIFF
--- a/recipes-printing/cups/cups.inc
+++ b/recipes-printing/cups/cups.inc
@@ -1,7 +1,7 @@
 SUMMARY = "An Internet printing system for Unix"
 SECTION = "console/utils"
 LICENSE = "GPLv2 & LGPLv2"
-DEPENDS = "gnutls libgcrypt libpng jpeg dbus dbus-glib zlib libusb"
+DEPENDS = "pkgconfig-native gnutls libgcrypt libpng jpeg dbus dbus-glib zlib libusb"
 
 SRC_URI = "https://github.com/apple/cups/releases/download/release-${PV}/${BP}-source.tar.gz \
            file://use_echo_only_in_init.patch \


### PR DESCRIPTION
Pkgconfig-native is necessary to build cups with libusb support